### PR TITLE
Fix link to tutorial in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,5 +2,5 @@
 
 Code for the fifth part of a tutorial series on building apps with LitElement. This part covers offline use and PWA.
 
-Tutorial: https://preview.vaadin.com/tutorials/lit-element/pwa-and-offline
+Tutorial: https://vaadin.com/tutorials/lit-element/pwa-and-offline
 Video: https://youtu.be/ToxKlmqgZHw


### PR DESCRIPTION
Fix link to tutorial, fixes vaadin-learning-center/lit-element-tutorial-pwa-and-offline#2